### PR TITLE
Add 404.md with custom message; add CLI redirects from old site

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,7 +8,26 @@ export default defineConfig({
     redirects:
     {
         '/docs': '/',
-        '/en': '/'
+        '/en': '/',
+        '/cli/command-reference/uds/': '/reference/cli/commands/uds',
+        '/cli/command-reference/uds_completion/': '/reference/cli/commands/uds_completion',
+        '/cli/command-reference/uds_completion_bash/': '/reference/cli/commands/uds_completion_bash',
+        '/cli/command-reference/uds_completion_fish/': '/reference/cli/commands/uds_completion_fish',
+        '/cli/command-reference/uds_completion_zsh/': '/reference/cli/commands/uds_completion_zsh',
+        '/cli/command-reference/uds_create/': '/reference/cli/commands/uds_create',
+        '/cli/command-reference/uds_deploy/': '/reference/cli/commands/uds_deploy',
+        '/cli/command-reference/uds_dev/': '/reference/cli/commands/uds_dev',
+        '/cli/command-reference/uds_dev_deploy/': '/reference/cli/commands/uds_dev_deploy',
+        '/cli/command-reference/uds_inspect/': '/reference/cli/commands/uds_inspect',
+        '/cli/command-reference/uds_logs/': '/reference/cli/commands/uds_logs',
+        '/cli/command-reference/uds_monitor/': '/reference/cli/commands/uds_monitor',
+        '/cli/command-reference/uds_monitor_pepr/': '/reference/cli/commands/uds_monitor_pepr',
+        '/cli/command-reference/uds_publish/': '/reference/cli/commands/uds_publish',
+        '/cli/command-reference/uds_pull/': '/reference/cli/commands/uds_pull',
+        '/cli/command-reference/uds_remove/': '/reference/cli/commands/uds_remove',
+        '/cli/command-reference/uds_run/': '/reference/cli/commands/uds_run',
+        '/cli/command-reference/uds_ui/': '/reference/cli/commands/uds_ui',
+        '/cli/command-reference/uds_version/': '/reference/cli/commands/uds_version',
     },
     integrations: [starlight({
         defaultLocale: 'en',

--- a/src/content/docs/404.md
+++ b/src/content/docs/404.md
@@ -1,0 +1,9 @@
+---
+title: '404'
+template: splash
+editUrl: false
+lastUpdated: false
+hero:
+  title: '404'
+  tagline: Page not found. If you came to this page via search results, we're currently in the process of migrating content and some URLs may not be accurate. Please return to the <a href="/">docs home</a> or use the search above to find what you're looking for. We apologize for the inconvenience!
+---


### PR DESCRIPTION
This PR adds a [custom 404 error ](https://starlight.astro.build/guides/customization/#custom-404-page) to inform users that links may not align correctly given the shift to the new site. It also adds some redirects for the CLI commands.