### PR TITLE
chore: unhide mission-capabilities docs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -102,6 +102,13 @@ gtag('config', 'G-57TRKPHZXN');
                 collapsed: true
             },
             {
+                label: 'Mission Capabilities',
+                autogenerate: {
+                    directory: 'mission-capabilities'
+                },
+                collapsed: true
+            },
+            {
                 label: 'Reference',
                 autogenerate: {
                     directory: 'reference'


### PR DESCRIPTION
Mission capabilities looks to be a complete doc chunk copied over from the old docs site.  Since it's visible via searching, we should expose this section in the navigation sidebar.  Especially as we continue to demo SWF and build more documentation and references around it.