### PR TITLE
Add build hook for scheduled deploy

### DIFF
--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -1,0 +1,15 @@
+name: Trigger Netlify Build
+on:
+  schedule:
+    # Runs at 00:00 UTC every day
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+
+jobs:
+  build_prod:
+    name: Scheduled Prod Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Curl request
+        run: curl -X POST -d {} ${{ secrets.NETLIFY_PROD_BUILD_HOOK }}


### PR DESCRIPTION
Add an action for building daily, using code from the website repo, also referenced [here](https://answers.netlify.com/t/scheduling-builds-and-deploys-with-netlify/2563/19).

Adresses #103 