### PR TITLE
chore: add renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+  "extends": [
+    "github>defenseunicorns/uds-common//config/renovate.json5",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "ignorePresets": [":ignoreModulesAndTests"],
+  "branchConcurrentLimit": 0,
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0
+}


### PR DESCRIPTION
Adds a basic renovate config to start, using the common config + configuration to allow fast PR creation with semantic commits.

Resolves https://github.com/defenseunicorns/uds-docs/issues/111