### PR TITLE
chore: switch landing page link to prerequisites

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,7 +29,7 @@ const sections = [
         title: 'Get Started',
         links: [
             {title: 'Why UDS?', href: 'overview/why-uds'},
-            {title: 'Prerequisites', href: 'reference/uds-core/prerequisites'},
+            {title: 'Basic Requirements', href: 'getting-started/basic-requirements'},
             {title: 'Install & Deploy UDS', href: 'getting-started/install-and-deploy-uds'},
             {title: 'What is a UDS Bundle?', href: '/structure/bundles/'}
         ]
@@ -37,6 +37,7 @@ const sections = [
     {
         title: 'Working with UDS Core',
         links: [
+            {title: 'Prerequisites', href: '/reference/uds-core/prerequisites'},
             {title: 'Bundle Overrides', href: '/reference/bundles/overrides'},
             {title: 'Distribution Support', href: '/reference/uds-core/distribution-support/'},
             {title: 'Functional Layers', href: '/reference/uds-core/functional-layers/'},


### PR DESCRIPTION
Also open to adding this link elsewhere, but I think this is more relevant/helpful to link up front as compared to the basic requirements doc which is more focused on requirements to run the demo bundle.