### PR TITLE
feat: add image zoom plugin

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import starlight from '@astrojs/starlight';
 import tailwind from "@astrojs/tailwind";
 import starlightDocSearch from '@astrojs/starlight-docsearch';
 import starlightLinksValidator from 'starlight-links-validator';
+import starlightImageZoom from 'starlight-image-zoom';
 
 // https://astro.build/config
 export default defineConfig({
@@ -41,7 +42,8 @@ export default defineConfig({
                 apiKey: 'f3cce33f634f204c0a97446f7c241e03',
                 indexName: 'uds-defenseunicorns',
                 insights: true
-            })
+            }),
+            starlightImageZoom()
         ],
         defaultLocale: 'root',
         locales: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "flowbite": "^2.5.2",
         "posthog-js": "^1.205.0",
         "sharp": "^0.33.5",
+        "starlight-image-zoom": "^0.10.1",
         "starlight-links-validator": "^0.14.1",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.7.3",
@@ -7463,6 +7464,22 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/starlight-image-zoom": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/starlight-image-zoom/-/starlight-image-zoom-0.10.1.tgz",
+      "integrity": "sha512-1uEwijShhFFcYA++lDmFV32WmZkpp/VMvD4+PC5h+7InnyPGMiT+mSVJzbddNEit44OxM5kxbO6/OqcBtjKpOA==",
+      "dependencies": {
+        "rehype-raw": "^7.0.0",
+        "unist-util-visit": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.30.0"
+      }
     },
     "node_modules/starlight-links-validator": {
       "version": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "flowbite": "^2.5.2",
     "posthog-js": "^1.205.0",
     "sharp": "^0.33.5",
+    "starlight-image-zoom": "^0.10.1",
     "starlight-links-validator": "^0.14.1",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.3",


### PR DESCRIPTION
Adding plugin that allows for viewing images in larger format without having to go to a different tab or downloading and viewing.