### PR TITLE
fix: Tutorial UDS Core Deploy Uses Expired Cert, Podinfo Unreachable

### DIFF
--- a/src/content/docs/tutorials/deploy-with-uds-core.md
+++ b/src/content/docs/tutorials/deploy-with-uds-core.md
@@ -115,7 +115,7 @@ packages:
 
   - name: core
     repository: oci://ghcr.io/defenseunicorns/packages/uds/core
-    ref: 0.30.0-upstream
+    ref: 0.34.0-upstream
     # Set overrides for Keycloak SSO tutorial
     overrides:
       keycloak:


### PR DESCRIPTION
…e the ref listed is an older version of core with expired certificates and causes the the deployment of podinfo to be unsecure and the user is unable to open the page in a web browser.

#127 