### PR TITLE
chore: add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+* @defenseunicorns/uds-core
+
+# Additional privileged files
+/CODEOWNERS @jeff-mccoy @daveworth
+# NOTE: No E to catch LICENSE and LICENSING
+/LICENS* @jeff-mccoy @austenbryan


### PR DESCRIPTION
Adds the codeowners file, copying from uds-core