### PR TITLE
chore: remove unused flowbite dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,11 @@ you build and tag the image as `uds-docs`:
 
 `docker build -t uds-docs:latest .`
 
-`docker tag uds-docs uds-docs:latest`
-
 > [!NOTE]
 > The above image is based on [node:lts](https://hub.docker.com/_/node) and 
 [nginx-unprivileged](https://hub.docker.com/r/nginxinc/nginx-unprivileged).
 
-This project has support for Tailwind and Flowbite, but the latter is currently not enabled as it causes some minor 
-styling issues which need to be resolved.
+This project uses TailwindCSS.
 
 ## Starlight Basics
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@docsearch/js": "^3.8.2",
         "@fontsource/teko": "^5.1.1",
         "astro": "^5.1.3",
-        "flowbite": "^2.5.2",
         "posthog-js": "^1.205.0",
         "sharp": "^0.33.5",
         "starlight-image-zoom": "^0.11.0",
@@ -1811,40 +1810,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
-    "node_modules/@rollup/plugin-node-resolve": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
-      "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "@types/resolve": "1.20.2",
-        "deepmerge": "^4.2.2",
-        "is-module": "^1.0.0",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.78.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
@@ -2296,12 +2261,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-3.0.1.tgz",
       "integrity": "sha512-1MRgzpzY0hOp9pW/kLRxeQhUWwil6gnrUYd3oEpeYBqp/FexhaCPv3F8LsYr47gtUU45fO2cm1dbwkSrHEo8Uw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/resolve": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
-      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "license": "MIT"
     },
     "node_modules/@types/sax": {
@@ -3334,15 +3293,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/defu": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
@@ -3882,27 +3832,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/flowbite": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/flowbite/-/flowbite-2.5.2.tgz",
-      "integrity": "sha512-kwFD3n8/YW4EG8GlY3Od9IoKND97kitO+/ejISHSqpn3vw2i5K/+ZI8Jm2V+KC4fGdnfi0XZ+TzYqQb4Q1LshA==",
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.9.3",
-        "flowbite-datepicker": "^1.3.0",
-        "mini-svg-data-uri": "^1.4.3"
-      }
-    },
-    "node_modules/flowbite-datepicker": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/flowbite-datepicker/-/flowbite-datepicker-1.3.2.tgz",
-      "integrity": "sha512-6Nfm0MCVX3mpaR7YSCjmEO2GO8CDt6CX8ZpQnGdeu03WUCWtEPQ/uy0PUiNtIJjJZWnX0Cm3H55MOhbD1g+E/g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/plugin-node-resolve": "^15.2.3",
-        "flowbite": "^2.0.0"
       }
     },
     "node_modules/foreground-child": {
@@ -4679,12 +4608,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/is-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
-      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -6059,15 +5982,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/mini-svg-data-uri": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
-      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
-      "license": "MIT",
-      "bin": {
-        "mini-svg-data-uri": "cli.js"
       }
     },
     "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@docsearch/js": "^3.8.2",
     "@fontsource/teko": "^5.1.1",
     "astro": "^5.1.3",
-    "flowbite": "^2.5.2",
     "posthog-js": "^1.205.0",
     "sharp": "^0.33.5",
     "starlight-image-zoom": "^0.11.0",


### PR DESCRIPTION
After reviewing our docs site structure/code and the readme it appears that flowbite was never used in this repo. In the interest of reducing maintenance here I removed this dependency and cleaned up the readme.

If we do want to leverage flowbite in the future we could, but for now it doesn't make sense to carry around an extra dependency. Reviewing the dev deploy of the docs site I did not identify any issues with this removal.