### PR TITLE
fix: remove ADR folder to prevent build errors

### DIFF
--- a/scripts/integration-script.sh
+++ b/scripts/integration-script.sh
@@ -48,5 +48,6 @@ done
 # Clean up and remove the temp folder
 rm -rf temp
 
-# Remove the dev docs folders if present
+# Remove the dev and adr docs folders if present
 rm -rf "$TARGET_DIR/dev"
+rm -rf "$TARGET_DIR/adr"


### PR DESCRIPTION
Now that uds-cli has its ADRs under the docs folder, we need to exclude these from the site build.

Ref: https://github.com/defenseunicorns/uds-cli/commit/fbd11c7d1f30ca1dad2e94a16aef3e3400ee5bf4#diff-ae9dae6af462e29e1e083d22c47a42f59177a7b75a36a5c226d7b40825564669

Current build error:
```
6:24:44 PM: [InvalidContentEntryDataError] docs → adr/0001-bundle-schema-tooling data does not match collection schema.
6:24:44 PM: title: Required
```