### PR TITLE
docs: add link to upgrade doc

### DIFF
--- a/scripts/integration-script.sh
+++ b/scripts/integration-script.sh
@@ -3,7 +3,7 @@
 TARGET_DIR="src/content/docs/"
 
 repos=(
-    "https://github.com/defenseunicorns/uds-core/ upgrade-doc ./temp/uds-core"
+    "https://github.com/defenseunicorns/uds-core/ main ./temp/uds-core"
     "https://github.com/defenseunicorns/uds-identity-config main ./temp/uds-identity-config"
     "https://github.com/defenseunicorns/uds-cli main ./temp/cli"
 )


### PR DESCRIPTION
Adds a link on the landing page, taking you to the upgrade doc.

Depends on https://github.com/defenseunicorns/uds-core/pull/1784