### PR TITLE
chore: add tech leads as owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @defenseunicorns/tech-leads
+* @defenseunicorns/uds-core @defenseunicorns/tech-leads
 
 /src/content/docs/registry/* @defenseunicorns/uds-experience
 /src/assets/* @defenseunicorns/uds-experience 


### PR DESCRIPTION
It seems reasonable to expect tech leads to own the quality of uds-docs. The docs span just uds-foundations team. 