### PR TITLE
fix: themeing of borders

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -9,14 +9,6 @@
     --sl-content-width: 50rem;
     color-scheme: dark;
 
-    *,
-    :before,
-    :after {
-        border-width: 0;
-        border-style: solid;
-        border-color: #e5e7eb;
-    }
-
     a,
     a:hover {
         text-decoration: none;


### PR DESCRIPTION
A few pages to compare:

Pepr Policies - note the table row dividers and colored stripe on left of >note:
- Previous: https://deploy-preview-214--uds.netlify.app/reference/configuration/pepr-policies/
- Current: https://uds.defenseunicorns.com/reference/configuration/pepr-policies/
- This PR: https://deploy-preview-300--uds.netlify.app/reference/configuration/pepr-policies/

Homepage - note the borders around boxes and buttons:
- Previous: https://deploy-preview-214--uds.netlify.app/
- Current: https://uds.defenseunicorns.com/
- This PR: https://deploy-preview-300--uds.netlify.app/

Fixes https://github.com/defenseunicorns/uds-docs/issues/299