### PR TITLE
fix: tutorial missing Keycloak overrides for Linux kernel >=6.12

### DIFF
--- a/src/content/docs/tutorials/deploy-with-uds-core.md
+++ b/src/content/docs/tutorials/deploy-with-uds-core.md
@@ -124,6 +124,17 @@ packages:
             - path: additionalIgnoredNamespaces
               value:
                 - uds-dev-stack
+      keycloak:
+        keycloak:
+          variables:
+            - name: KEYCLOAK_HEAP_OPTIONS
+              description: "Sets the JAVA_OPTS_KC_HEAP environment variable in Keycloak"
+              path: env[0].value
+          values:
+            - path: env[0]
+              value:
+                name: JAVA_OPTS_KC_HEAP
+                value: "-XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=70 -XX:InitialRAMPercentage=50 -XX:MaxRAM=1G"
 
   - name: podinfo
     path: ./


### PR DESCRIPTION
On systems with Linux kernel 6.12+, Keycloak will fail to come up when attempting to run through the tutorial as the core package is missing the overrides necessary to enable this (see https://github.com/defenseunicorns/uds-core/pull/1218 for more details).