### PR TITLE
fix: override repo clones with local directory

### DIFF
--- a/scripts/integration-script.sh
+++ b/scripts/integration-script.sh
@@ -69,12 +69,6 @@ for repo_info in "${repos[@]}"; do
   fi
   src_subpath="docs${dest:+/$dest}"
   dest_dir="$TARGET_DIR${dest:+/$dest}"
-  # If this is the tutorials destination, ensure a clean slate once
-  if [[ -n "$dest" && "$dest" == "tutorials" && -z "${CLEANED_TUTORIALS:-}" ]]; then
-    rm -rf "$dest_dir"
-    mkdir -p "$dest_dir"
-    CLEANED_TUTORIALS=1
-  fi
   mkdir -p "$dest_dir"
 
   # Local override path


### PR DESCRIPTION
Update the integration script to allow for overriding the cloning of a repo. This allows users to provide an override for the default github urls so that a repo can be tested with a local directory. 

for example using:
```
DOCS_OVERRIDES="uds-core=$(pwd)/.." npm run build
```
from inside of `uds-core/` will use the local directory instead of the github one. This will allow for doing link validation or checking that repos docs build before it gets to uds-docs.