### PR TITLE
fix: update headers for HSTS and clickjacking protections

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,14 @@
 [build]
   command = "npm run build"
   publish = "dist"
+[[headers]]
+  for = "/*"
+  [headers.values]
+    # HSTS: enables HTTPS-only once the browser has seen it.
+    Strict-Transport-Security = "max-age=31536000"
+
+    # Clickjacking protection (modern)
+    Content-Security-Policy = "frame-ancestors 'none'"
+
+    # Clickjacking protection (legacy but still widely scanned)
+    X-Frame-Options = "DENY"


### PR DESCRIPTION
Address scan findings, specifically flagging:
	•	HSTS missing (Strict-Transport-Security)
	•	CSP frame-ancestors missing/permissive
	•	X-Frame-Options missing/permissive