### PR TITLE
chore: add foundry for uds-packages codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,7 @@
 * @defenseunicorns/uds-core
 
 /src/content/docs/registry/* @defenseunicorns/uds-registry
+/src/content/docs/uds-packages/* @defenseunicorns/uds-foundry
 
 # Additional privileged files
 /CODEOWNERS @jeff-mccoy @daveworth


### PR DESCRIPTION
- Add foundry as CODEOWERS for `uds-packages` docs as a part of the uds-packages docs effort.
- The path is subject to change in the future, but this should help us to start iterating.