### PR TITLE
chore: update supported artifacts

### DIFF
--- a/src/content/docs/registry/supported-artifacts.md
+++ b/src/content/docs/registry/supported-artifacts.md
@@ -17,6 +17,10 @@ Here is a list of the supported artifact types:
 - OpenTofu Providers
 - OCI Artifacts[^1]
 
+**Recommended: Zarf Packages (including UDS Packages).** While UDS Registry can store multiple OCI artifact types, Zarf packages are the preferred, first-class unit of delivery. A Zarf package bundles the application's container images, Helm charts, and manifests into a single deployable artifact, making it the most reliable way to move software across disconnected and mission environments.
+
+UDS Packages build on Zarf (a Zarf package plus UDS-specific integration) and are the recommended format for delivering applications into UDS Core, preserving the metadata and structure needed for secure, repeatable deployments.
+
 ### Supported Features
 
 UDS Registry supports publishing artifacts with standard OCI tooling. For every supported artifact type you can:


### PR DESCRIPTION
## Summary

Updates the Registry docs to clarify supported artifact types and scanning support.

## What changed

- Reworked supported-artifacts.md to separate:
  - supported artifact types
  - supported features (push/pull + scan status)
- Moved OCI compatibility details to a footnote.
- Updated scan status table entries.
- Fixed table contrast for light mode.
- Added footnote styles.