### PR TITLE
chore: add links to zarf and uds packages

### DIFF
--- a/src/content/docs/registry/supported-artifacts.md
+++ b/src/content/docs/registry/supported-artifacts.md
@@ -17,7 +17,7 @@ Here is a list of the supported artifact types:
 - OpenTofu Providers
 - OCI Artifacts[^1]
 
-**Recommended: [Zarf Packages](https://docs.zarf.dev/) (Including [UDS Packages](/structure/packages/)).** While UDS Registry can store multiple OCI artifact types, Zarf packages are the preferred, first-class unit of delivery. A Zarf package bundles the application's container images, Helm charts, and manifests into a single deployable artifact, making it the most reliable way to move software across disconnected and mission environments.
+**Recommended: [Zarf Packages](https://docs.zarf.dev/ref/packages/) (Including [UDS Packages](/structure/packages/)).** While UDS Registry can store multiple OCI artifact types, Zarf packages are the preferred, first-class unit of delivery. A Zarf package bundles the application's container images, Helm charts, and manifests into a single deployable artifact, making it the most reliable way to move software across disconnected and mission environments.
 
 UDS Packages build on Zarf (a Zarf package plus UDS-specific integration) and are the recommended format for delivering applications into UDS Core, preserving the metadata and structure needed for secure, repeatable deployments.
 


### PR DESCRIPTION
Adds Zarf and UDS Package doc links to UDS Registry supported artifacts page.