### PR TITLE
fix(docs): remove main branch release for tagged releases

### DIFF
--- a/src/products.json
+++ b/src/products.json
@@ -1,10 +1,8 @@
 [
   {
-    "repo": "defenseunicorns/uds-core",
-    "branch": "main"
+    "repo": "defenseunicorns/uds-core"
   },
   {
-    "repo": "defenseunicorns/uds-cli",
-    "branch": "main"
+    "repo": "defenseunicorns/uds-cli"
   }
 ]


### PR DESCRIPTION
# NOT TO MERGE UNTIL AFTER CORE 1.0 RELEASE

### Description

We want to publish tagged releases of UDS Core and CLI. This reverts the main branch deployment (which was necessary for reviewing and dev-ing) to use the latest tagged release.

Currently not passing because latest releases don't contain a config file