### PR TITLE
Add UDS Registry Documentation from legacy docs site

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -185,7 +185,7 @@ const frontmatter = {
             <img src="/assets/UDS_Registry_Logo_White.svg" alt="UDS Registry" class="card-logo card-logo-dark" />
             <img src="/assets/UDS_Registry_Logo_Dark.svg" alt="UDS Registry" class="card-logo card-logo-light" />
             A curated catalog of pre-built, scanned, and SBOMed UDS packages. Browse available packages, inspect CVE reports, and pull artifacts to deploy.
-            <a href="https://registry.defenseunicorns.com/" class="card-link" aria-label="UDS Registry" target="_blank" rel="noopener noreferrer"></a>
+            <a href="/registry/" class="card-link" aria-label="UDS Registry" target="_blank" rel="noopener noreferrer"></a>
         </Card>
 
         <Card title="Open-Source Foundation">

--- a/src/products.json
+++ b/src/products.json
@@ -6,5 +6,9 @@
   {
     "repo": "defenseunicorns/uds-cli",
     "branch": "main"
+  },
+  {
+    "repo": "defenseunicorns/uds-registry",
+    "branch": "main"
   }
 ]


### PR DESCRIPTION
Adding UDS-Registry to new docs.* endpoint, one-to-one lift/shift from legacy site.

- Added product to /products.json.
- Updated link to documentation overview, away from Registry product page.

UDS Registry Docs PR: https://github.com/defenseunicorns/uds-registry/pull/2418