### PR TITLE
fix: legacy docs no indexing

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,3 +12,6 @@
 
     # Clickjacking protection (legacy but still widely scanned)
     X-Frame-Options = "DENY"
+
+    # Block search engine indexing.
+    X-Robots-Tag = "noindex, nofollow"

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -25,4 +25,6 @@ import PostHog from './PostHog.astro';
 
 <PostHog/>
 
+<meta name="robots" content="noindex, nofollow" />
+
 <Default><slot /></Default>


### PR DESCRIPTION
de-index legacy docs from google. Once Google re-crawls those pages and sees the noindex tags, they'll drop out of results.