### PR TITLE
fix: add google ownership file

### DIFF
--- a/public/google0f1338bbe190aa20.html
+++ b/public/google0f1338bbe190aa20.html
@@ -1,0 +1,1 @@
+google-site-verification: google0f1338bbe190aa20.html


### PR DESCRIPTION
Adds a Google Search Console ownership verification file to public/ so we can verify ownership of uds.defenseunicorns.com in Google Search Console and use the Removals Tool to de-index the old docs site.