### PR TITLE
fix: force gfm to true

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -231,6 +231,7 @@ export default defineConfig({
     react(),
   ],
   markdown: {
+    gfm: true,
     remarkPlugins: [
       [remarkLinkRewrite, {
         products: linkRewriteProducts,


### PR DESCRIPTION
Starlight `updateConfig()` seems to be stripping defaults from Astro. Since Starlight integrates to Astro, it seems like its not respecting defaults. Just added `gfm: true` and it rendered correctly. I tested by adding this line then just running `npm run build` and `npm run dev`.

https://github.com/withastro/starlight/blob/4f13ba3a34652985a955c55849b4f4d191a1453a/packages/starlight/index.ts#L104-L106

https://github.com/withastro/starlight/blob/4f13ba3a34652985a955c55849b4f4d191a1453a/packages/starlight/index.ts#L172-L175